### PR TITLE
feat!:(TON-2931) Change TonClient4Adapter's constructor signature

### DIFF
--- a/packages/adapter/src/tonclient4/index.spec.ts
+++ b/packages/adapter/src/tonclient4/index.spec.ts
@@ -9,7 +9,7 @@ describe('TonClient4Adapter', () => {
   let tonClient: TonClient4Adapter;
 
   beforeEach(() => {
-    tonClient = new TonClient4Adapter(network, apiKey);
+    tonClient = new TonClient4Adapter({ network, apiKey });
   });
 
   it('should initialize with correct properties', () => {
@@ -377,7 +377,7 @@ describe('TonClient4Adapter', () => {
       'Content-Type': 'application/json',
       },
     });
-    
+
 });
 });
 

--- a/packages/adapter/src/tonclient4/index.ts
+++ b/packages/adapter/src/tonclient4/index.ts
@@ -29,12 +29,15 @@ class TonClient4Adapter {
   network: Network
   apiKey: string
 
-  constructor(
-    network: Network,
-    apiKey: string
-  ) {
-    this.network = network;
+  constructor({
+    apiKey,
+    network,
+  }: {
+    apiKey: string;
+    network: "mainnet" | "testnet";
+  }) {
     this.apiKey = apiKey;
+    this.network = network;
     this.endpoint = getJsonRpcUrl(network, apiKey);
   }
 
@@ -157,7 +160,7 @@ class TonClient4Adapter {
     * To support the tonclient4 interface get account by seqNo, we need to support it from our tonx api response in future
     */
     const result = await this.sendTonhubRequest('/block/' + seqno + '/' + address.toString({ urlSafe: true }), 'GET');
-    
+
     let account = accountCodec.safeParse(result);
     if (!account.success) {
       throw Error('Mailformed response');
@@ -179,7 +182,7 @@ class TonClient4Adapter {
     if (!account.success) {
         throw Error('Mailformed response');
     }
-    
+
     return account.data;
   }
 
@@ -266,7 +269,7 @@ class TonClient4Adapter {
      */
   async getAccountTransactionsParsed(address: Address, lt: bigint, hash: Buffer, count: number = 20) {
     const path = '/account/' + address.toString({ urlSafe: true }) + '/tx/parsed/' + lt.toString(10) + '/' + toUrlSafe(hash.toString('base64')) + '?' + new URLSearchParams({ count: count.toString() }).toString();
-    
+
     const tonhubData = await this.sendTonhubRequest(path, 'GET');
 
     /*
@@ -357,7 +360,7 @@ class TonClient4Adapter {
      * @returns opened contract
      */
   open<T extends Contract>(contract: T) {
-    
+
     return openContract<T>(contract, (args) => createProvider(this, null, args.address, args.init));
   }
 


### PR DESCRIPTION
## Summary

Make the constructor signature of `TonClient4Adapter` match the docs, also matching other adapters. Namely, from `constructor(network, apiKey)` to `constructor({ network, apiKey })`. Unit tests are still broken, but at least the type checks.

## Ticket(s)
https://tonfura.atlassian.net/browse/TON-2931

## Type of change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Screenshot(s)

<!-- Please attach the screenshot to describe the changes -->

## Test Steps

<!-- Please provide few step to reproduce feature -->

## Reference Document(s)

<!-- Please attach related reference documents of ticket -->

## Checklist

<!-- Check following items before merge -->

- [x] Remove unnecessary console or comment
- [x] Add unit tests

